### PR TITLE
feat(ci): create build-binaries upon GitHub Release 👷

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-gnu]
+linker = "/usr/bin/x86_64-w64-mingw32-gcc"

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -29,7 +29,7 @@ jobs:
           - image: macos-latest
             target: x86_64-apple-darwin
           - image: ubuntu-latest
-            target: x86_64-windows-gnu
+            target: x86_64-pc-windows-gnu
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -65,6 +65,7 @@ jobs:
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
       - name: Rename binary
         run: |
+          tree
           cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
       - name: Checksum
         run: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Install Rust stable
         run: |
           rustup toolchain install stable --target ${{ matrix.target }}
+      - if: contains(matrix.target, 'windows')
+        name: Install Windows dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-mingw-w64
       - if: contains(matrix.target, 'apple')
         name: Install Apple dependencies
         run: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -57,33 +57,32 @@ jobs:
       - name: Build
         run: |
           cargo build --release --target ${{ matrix.target }}
-      - id: package-name
-        name: Cargo package name
-        run: |
-          cargo install cargo-get
-          package_name=$(cargo get --name)
-          echo "package-name=${package_name}" >> $GITHUB_OUTPUT
+      - name: Get package name
+        id: package-name
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          flags: --name
       - name: Rename binary
         run: |
           tree
-          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
       - name: Checksum
         run: |
           cd target/${{ matrix.target }}/release
-          sha256sum ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }} > ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+          sha256sum ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }} > ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+          name: ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
           if-no-files-found: error
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Upload assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
   

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,80 @@
+name: build-binary
+
+concurrency:
+  group: build-binary-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.image }}
+    strategy:
+      matrix:
+        include:
+          - image: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - image: macos-latest
+            target: x86_64-apple-darwin
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --target ${{ matrix.target }}
+      - if: contains(matrix.target, 'apple')
+        name: Install Apple dependencies
+        run: |
+          brew install openssl coreutils
+      - name: Build
+        run: |
+          cargo build --release --target ${{ matrix.target }}
+      - id: package-name
+        name: Cargo package name
+        run: |
+          cargo install cargo-get
+          package_name=$(cargo get --name)
+          echo "package-name=${package_name}" >> $GITHUB_OUTPUT
+      - name: Rename binary
+        run: |
+          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+      - name: Checksum
+        run: |
+          cd target/${{ matrix.target }}/release
+          sha256sum ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }} > ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+          if-no-files-found: error
+      - if: github.event_name == 'release' && github.event.action == 'published'
+        name: Upload assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -28,6 +28,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - image: macos-latest
             target: x86_64-apple-darwin
+          - image: ubuntu-latest
+            target: x86_64-windows-gnu
       fail-fast: false
     steps:
       - name: Checkout
@@ -78,5 +80,4 @@ jobs:
           files: |
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
-  # TODO: windows
   

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -111,6 +111,7 @@ jobs:
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
       - name: Rename binary
         run: |
+          mkdir target/${{ matrix.target }}/release
           cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}.exe target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
       - name: Checksum
         run: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -78,57 +78,5 @@ jobs:
           files: |
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
-  windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-pc-windows-msvc
-          - target: x86_64-pc-windows-gnu
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Cache cargo
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Rust stable
-        run: |
-          rustup toolchain install stable --target ${{ matrix.target }}
-      - name: Build
-        run: |
-          cargo build --release --target ${{ matrix.target }}
-      - id: package-name
-        name: Cargo package name
-        run: |
-          cargo install cargo-get
-          $package_name = cargo get --name
-          echo "package-name=${package_name}" >> $GITHUB_OUTPUT
-      - name: Rename binary
-        run: |
-          mkdir target/${{ matrix.target }}/release
-          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}.exe target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
-      - name: Checksum
-        run: |
-          cd target/${{ matrix.target }}/release
-          sha256sum ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe > ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe.sha256
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
-          path: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe.sha256
-          if-no-files-found: error
-      - if: github.event_name == 'release' && github.event.action == 'published'
-        name: Upload assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe.sha256
+  # TODO: windows
+  

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -19,7 +19,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  unix:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
@@ -28,8 +28,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - image: macos-latest
             target: x86_64-apple-darwin
-          - image: windows-latest
-            target: x86_64-pc-windows-gnu
       fail-fast: false
     steps:
       - name: Checkout
@@ -80,3 +78,56 @@ jobs:
           files: |
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+          - target: x86_64-pc-windows-gnu
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --target ${{ matrix.target }}
+      - name: Build
+        run: |
+          cargo build --release --target ${{ matrix.target }}
+      - id: package-name
+        name: Cargo package name
+        run: |
+          cargo install cargo-get
+          package_name=$(cargo get --name)
+          echo "package-name=${package_name}" >> $GITHUB_OUTPUT
+      - name: Rename binary
+        run: |
+          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}.exe target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
+      - name: Checksum
+        run: |
+          cd target/${{ matrix.target }}/release
+          sha256sum ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe > ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe.sha256
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe.sha256
+          if-no-files-found: error
+      - if: github.event_name == 'release' && github.event.action == 'published'
+        name: Upload assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.exe.sha256

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -72,24 +72,24 @@ jobs:
           fi
       - name: Rename binary
         run: |
-          cp target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }} target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
       - name: Checksum
         run: |
           cd target/${{ matrix.target }}/release
-          sha256sum ${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }} > ${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}.sha256
+          sha256sum ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }} > ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
+          name: ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
           if-no-files-found: error
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Upload assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
   

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -62,27 +62,34 @@ jobs:
         uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
+      - name: Get binary name
+        id: binary-name
+        run: |
+          if [[ "${{ matrix.target }}" == *"windows"* ]]; then
+            echo "binary-name=${{ steps.package-name.outputs.metadata }}.exe" >> $GITHUB_OUTPUT
+          else
+            echo "binary-name=${{ steps.package-name.outputs.metadata }}" >> $GITHUB_OUTPUT
+          fi
       - name: Rename binary
         run: |
-          tree
-          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }} target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
       - name: Checksum
         run: |
           cd target/${{ matrix.target }}/release
-          sha256sum ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }} > ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
+          sha256sum ${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }} > ${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}.sha256
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+          name: ${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}.sha256
           if-no-files-found: error
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Upload assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.binary-name.outputs.binary-name }}-${{ matrix.target }}.sha256
   

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -28,6 +28,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - image: macos-latest
             target: x86_64-apple-darwin
+          - image: windows-latest
+            target: x86_64-pc-windows-gnu
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -19,7 +19,7 @@ permissions:
   contents: write
 
 jobs:
-  unix:
+  build:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -107,7 +107,7 @@ jobs:
         name: Cargo package name
         run: |
           cargo install cargo-get
-          package_name=$(cargo get --name)
+          $package_name = cargo get --name
           echo "package-name=${package_name}" >> $GITHUB_OUTPUT
       - name: Rename binary
         run: |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ cargo-get uses rustfmt for formatting and clippy for linting.
 
 ### Installation
 
+### Pre-built Binaries
+
+Download the latest release from the following link:
+
+<https://github.com/nicolaiunrein/cargo-get/releases/latest>
+
+Place the binary in your `$PATH` and rename it to `cargo-get`.
+
+
+### Cargo
+
 Ensure that you have a fairly recent version of rust/cargo installed.
 
 ```

--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ cargo-get uses rustfmt for formatting and clippy for linting.
 
 ### Pre-built Binaries
 
-Download the latest release from the following link:
-
-<https://github.com/nicolaiunrein/cargo-get/releases/latest>
-
-Place the binary in your `~/.cargo/bin/` and rename it to `cargo-get`.
+1. Download the binary for your CPU architecture from the [GitHub latest release][release].
+2. Make the binary executable using `chmod +x`
+3. Place the binary in your `$PATH` and rename it to `cargo-get`.
 
 
 ### Cargo
@@ -139,3 +137,5 @@ some-other-project
 $ cargo get -n
 current-project
 ```
+
+[release]: https://github.com/nicolaiunrein/cargo-get/releases/latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/cargo-get.svg)](https://crates.io/crates/cargo-get)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/nicolaiunrein/cargo-get/CI)
+[![build-binary](https://github.com/meysam81/cargo-get/actions/workflows/build-binary.yml/badge.svg)](https://github.com/nicolaiunrein/cargo-get/releases/latest)
 
 ### Overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/cargo-get.svg)](https://crates.io/crates/cargo-get)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/nicolaiunrein/cargo-get/CI)
-[![build-binary](https://github.com/meysam81/cargo-get/actions/workflows/build-binary.yml/badge.svg)](https://github.com/nicolaiunrein/cargo-get/releases/latest)
+[![build-binary](https://github.com/nicolaiunrein/cargo-get/actions/workflows/build-binary.yml/badge.svg)](https://github.com/nicolaiunrein/cargo-get/releases/latest)
 
 ### Overview
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Download the latest release from the following link:
 
 <https://github.com/nicolaiunrein/cargo-get/releases/latest>
 
-Place the binary in your `$PATH` and rename it to `cargo-get`.
+Place the binary in your `~/.cargo/bin/` and rename it to `cargo-get`.
 
 
 ### Cargo


### PR DESCRIPTION
This PR will create a binary release upon GitHub Release.
You can see an example run [here](https://github.com/meysam81/cargo-get/actions/runs/5758242523) and the result of such run [over here in the Assets section](https://github.com/meysam81/cargo-get/releases/tag/0.1.0).

It allows the users not to have `cargo` installed if they don't want to run the binary using `cargo run`.
