### PR TITLE
feat(ci): publish on GitHub Action Marketplace 🔖

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Get package name
         id: cargo-name
         # uses: nicolaiunrein/cargo-get@master
-        uses: meysam81/cargo-get@master
+        uses: meysam81/cargo-get@main
         with:
           flags: --name
       - name: Get package author
         id: cargo-author
-        uses: meysam81/cargo-get@master
+        uses: meysam81/cargo-get@main
         with:
           flags: --author

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,11 +2,10 @@ name: github-actions
 
 on:
   push:
-    # branches: master
-    branches: main
+    branches: master
 
   pull_request:
-    branches: main
+    branches: master
 
 jobs:
   actions:
@@ -16,25 +15,22 @@ jobs:
         uses: actions/checkout@master
       - name: Get package name
         id: cargo-name
-        # uses: nicolaiunrein/cargo-get@master
-        uses: meysam81/cargo-get@main
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
       - name: Get package name with root
         id: cargo-name-root
-        # uses: nicolaiunrein/cargo-get@master
-        uses: meysam81/cargo-get@main
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
           options: --root .
       - name: Get package version
         id: cargo-version
-        # uses: nicolaiunrein/cargo-get@master
-        uses: meysam81/cargo-get@main
+        uses: nicolaiunrein/cargo-get@master
         with:
           subcommand: version
       - name: Get package author
         id: cargo-author
-        uses: meysam81/cargo-get@main
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --authors

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,8 +20,21 @@ jobs:
         uses: meysam81/cargo-get@main
         with:
           flags: --name
+      - name: Get package name with root
+        id: cargo-name-root
+        # uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@main
+        with:
+          flags: --name
+          options: --root .
+      - name: Get package version
+        id: cargo-version
+        # uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@main
+        with:
+          subcommand: version
       - name: Get package author
         id: cargo-author
         uses: meysam81/cargo-get@main
         with:
-          flags: --author
+          flags: --authors

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Get package name
-        id: cargo-get
+        id: cargo-name
         # uses: nicolaiunrein/cargo-get@master
         uses: meysam81/cargo-get@master
         with:
           flags: --name
       - name: Get package author
-        id: cargo-get
+        id: cargo-author
         uses: meysam81/cargo-get@master
         with:
           flags: --author

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,27 @@
+name: github-actions
+
+on:
+  push:
+    # branches: master
+    branches: main
+
+  pull_request:
+    branches: main
+
+jobs:
+  actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Get package name
+        id: cargo-get
+        # uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
+        with:
+          flags: --name
+      - name: Get package author
+        id: cargo-get
+        uses: meysam81/cargo-get@master
+        with:
+          flags: --author

--- a/README.md
+++ b/README.md
@@ -127,3 +127,25 @@ some-other-project
 $ cargo get -n
 current-project
 ```
+
+### GitHub Actions
+
+#### Package name
+
+```yaml
+      - name: Get package name
+        id: cargo-get
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          flags: --name
+```
+
+#### Package author
+
+```yaml
+      - name: Get package author
+        id: cargo-get
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          flags: --author
+```

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: cargo-get
-author: n.unrein@gmail.com
+author: contact@meysam.io
 branding:
   color: red
   icon: upload

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+name: cargo-get
+author: n.unrein@gmail.com
+branding:
+  color: red
+  icon: upload
+description: Get cargo package metadata
+inputs:
+  flags:
+    description: "Flags to pass to cargo get (default: package name)"
+    required: false
+    default: --name
+  options:
+    description: "Options to pass to cargo get"
+    required: false
+    default: ""
+  subcommand:
+    description: "Subcommand to run"
+    required: false
+    default: ""
+outputs:
+  metadata:
+    description: "Cargo package metadata"
+    value: ${{ steps.cargo-get.outputs.metadata }}
+runs:
+  using: composite
+  steps:
+    - id: cargo-get
+      name: Cargo get metadata
+      run: |
+        metadata=$(cargo get ${{ inputs.flags }} ${{ inputs.options }} ${{ inputs.subcommand }})
+        echo "metadata=$metadata" >> $GITHUB_OUTPUT
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install cargo-get
+      run: |
+        cargo install cargo-get
+      shell: bash
     - id: cargo-get
       name: Cargo get metadata
       run: |

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: cargo-get
-author: contact@meysam.io
+author: n.unrein@gmail.com
 branding:
   color: red
   icon: upload


### PR DESCRIPTION
This will allow users to use this tool in their Github Actions as a step without having to install it manually (this CI will take care of that).

Here's an example use case: https://github.com/meysam81/cargo-get/actions/runs/5758535571/workflow

The following screenshots show how to create the action by releasing a new version and checking the box to "publish to the marketplace".

![image](https://github.com/nicolaiunrein/cargo-get/assets/30233243/fdc7bd1a-31de-46db-8c12-20e6b46c0e94)

![image](https://github.com/nicolaiunrein/cargo-get/assets/30233243/529d021c-d596-453b-b762-e2bb54ee77b0)
