### PR TITLE
feat: speed up github action ⚡️

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,21 +15,21 @@ jobs:
         uses: actions/checkout@v3
       - name: Get package name
         id: cargo-name
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
       - name: Get package name with root
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
           options: --root .
       - name: Get cargo-get version
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           subcommand: version
       - name: Get package author
         id: cargo-author
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --authors
       - name: Print package metadata
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get package name
         id: cargo-name
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
       - name: Print package metadata

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,22 +15,24 @@ jobs:
         uses: actions/checkout@master
       - name: Get package name
         id: cargo-name
-        uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
         with:
           flags: --name
       - name: Get package name with root
-        id: cargo-name-root
-        uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
         with:
           flags: --name
           options: --root .
-      - name: Get package version
-        id: cargo-version
-        uses: nicolaiunrein/cargo-get@master
+      - name: Get cargo-get version
+        uses: meysam81/cargo-get@master
         with:
           subcommand: version
       - name: Get package author
         id: cargo-author
-        uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
         with:
           flags: --authors
+      - name: Print package metadata
+        run: |
+          echo "Package name: ${{ steps.cargo-name.outputs.stdout }}"
+          echo "Package author: ${{ steps.cargo-author.outputs.stdout }}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -19,11 +19,13 @@ jobs:
         with:
           flags: --name
       - name: Get package name with root
+        id: cargo-name-root
         uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
           options: --root .
-      - name: Get cargo-get version
+      - name: Get package version
+        id: cargo-version
         uses: nicolaiunrein/cargo-get@master
         with:
           subcommand: version
@@ -32,7 +34,3 @@ jobs:
         uses: nicolaiunrein/cargo-get@master
         with:
           flags: --authors
-      - name: Print package metadata
-        run: |
-          echo "Package name: ${{ steps.cargo-name.outputs.stdout }}"
-          echo "Package author: ${{ steps.cargo-author.outputs.stdout }}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -34,8 +34,8 @@ jobs:
           flags: --authors
       - name: Print package metadata
         run: |
-          echo "Package name: ${{ steps.cargo-name.outputs.stdout }}"
-          echo "Package author: ${{ steps.cargo-author.outputs.stdout }}"
+          echo "Package name: ${{ steps.cargo-name.outputs.metadata }}"
+          echo "Package author: ${{ steps.cargo-author.outputs.metadata }}"
   macos:
     runs-on: macos-latest
     steps:
@@ -48,4 +48,4 @@ jobs:
           flags: --name
       - name: Print package metadata
         run: |
-          echo "Package name: ${{ steps.cargo-name.outputs.stdout }}"
+          echo "Package name: ${{ steps.cargo-name.outputs.metadata }}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,29 +8,44 @@ on:
     branches: master
 
 jobs:
-  actions:
+  linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Get package name
         id: cargo-name
-        uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
         with:
           flags: --name
       - name: Get package name with root
-        id: cargo-name-root
-        uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
         with:
           flags: --name
           options: --root .
-      - name: Get package version
-        id: cargo-version
-        uses: nicolaiunrein/cargo-get@master
+      - name: Get cargo-get version
+        uses: meysam81/cargo-get@master
         with:
           subcommand: version
       - name: Get package author
         id: cargo-author
-        uses: nicolaiunrein/cargo-get@master
+        uses: meysam81/cargo-get@master
         with:
           flags: --authors
+      - name: Print package metadata
+        run: |
+          echo "Package name: ${{ steps.cargo-name.outputs.stdout }}"
+          echo "Package author: ${{ steps.cargo-author.outputs.stdout }}"
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get package name
+        id: cargo-name
+        uses: meysam81/cargo-get@master
+        with:
+          flags: --name
+      - name: Print package metadata
+        run: |
+          echo "Package name: ${{ steps.cargo-name.outputs.stdout }}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,21 +15,21 @@ jobs:
         uses: actions/checkout@master
       - name: Get package name
         id: cargo-name
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
       - name: Get package name with root
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --name
           options: --root .
       - name: Get cargo-get version
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           subcommand: version
       - name: Get package author
         id: cargo-author
-        uses: meysam81/cargo-get@master
+        uses: nicolaiunrein/cargo-get@master
         with:
           flags: --authors
       - name: Print package metadata

--- a/action.yml
+++ b/action.yml
@@ -24,11 +24,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Cache installed binary
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo/bin/cargo-get
-        key: ${{ runner.os }}-cargo-get
     - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Linux'
       name: Install cargo-get
       run: |
@@ -42,8 +37,6 @@ runs:
       name: Install cargo-get
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
-        # for some reason unkonwn to me, this step ensures success of the next!
-        command -v curl grep cut tr
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-apple-darwin\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
         mkdir -p ~/.cargo/bin/
         curl -sSfLo ~/.cargo/bin/cargo-get "$download_link"

--- a/action.yml
+++ b/action.yml
@@ -29,11 +29,20 @@ runs:
       with:
         path: ~/.cargo/bin/cargo-get
         key: ${{ runner.os }}-cargo-get
-    - if: steps.cache.outputs.cache-hit != 'true'
+    - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Linux'
       name: Install cargo-get
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-unknown-linux-musl\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
+        mkdir -p ~/.cargo/bin/
+        curl -sSfL "$download_link" -o ~/.cargo/bin/cargo-get
+        chmod +x ~/.cargo/bin/cargo-get
+      shell: bash
+    - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'macOS'
+      name: Install cargo-get
+      run: |
+        current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
+        download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-apple-darwin\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
         mkdir -p ~/.cargo/bin/
         curl -sSfL "$download_link" -o ~/.cargo/bin/cargo-get
         chmod +x ~/.cargo/bin/cargo-get

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Linux'
+    - if: runner.os == 'Linux'
       name: Install cargo-get
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
@@ -33,7 +33,7 @@ runs:
         curl -sSfLo ~/.cargo/bin/cargo-get "$download_link"
         chmod +x ~/.cargo/bin/cargo-get
       shell: bash
-    - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'macOS'
+    - if: runner.os == 'macOS'
       name: Install cargo-get
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)

--- a/action.yml
+++ b/action.yml
@@ -42,16 +42,12 @@ runs:
       name: Install cargo-get
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
-        echo $current_target
+        # for some reason unkonwn to me, this step ensures success of the next!
         command -v curl grep cut tr
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-apple-darwin\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
-        echo $download_link
         mkdir -p ~/.cargo/bin/
-        ls -lh ~/.cargo/bin/
         curl -sSfLo ~/.cargo/bin/cargo-get "$download_link"
-        ls -lh ~/.cargo/bin/
         chmod +x ~/.cargo/bin/cargo-get
-        ls -lh ~/.cargo/bin/
       shell: bash
     - id: cargo-get
       name: Cargo get metadata

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,19 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install cargo-get
+    - name: Cache installed binary
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/bin/cargo-get
+        key: ${{ runner.os }}-cargo-get
+    - if: steps.cache.outputs.cache-hit != 'true'
+      name: Install cargo-get
       run: |
-        cargo install cargo-get
+        current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
+        download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-unknown-linux-musl\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
+        mkdir -p ~/.cargo/bin/
+        curl -sSfL "$download_link" -o ~/.cargo/bin/cargo-get
+        chmod +x ~/.cargo/bin/cargo-get
       shell: bash
     - id: cargo-get
       name: Cargo get metadata

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,7 @@ runs:
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
         echo $current_target
+        command -v curl grep cut tr
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-apple-darwin\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
         echo $download_link
         mkdir -p ~/.cargo/bin/

--- a/action.yml
+++ b/action.yml
@@ -42,10 +42,15 @@ runs:
       name: Install cargo-get
       run: |
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
+        echo $current_target
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-apple-darwin\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
+        echo $download_link
         mkdir -p ~/.cargo/bin/
+        ls -lh ~/.cargo/bin/
         curl -sSfLo ~/.cargo/bin/cargo-get "$download_link"
+        ls -lh ~/.cargo/bin/
         chmod +x ~/.cargo/bin/cargo-get
+        ls -lh ~/.cargo/bin/
       shell: bash
     - id: cargo-get
       name: Cargo get metadata

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-unknown-linux-musl\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
         mkdir -p ~/.cargo/bin/
-        curl -sSfL "$download_link" -o ~/.cargo/bin/cargo-get
+        curl -sSfLo ~/.cargo/bin/cargo-get "$download_link"
         chmod +x ~/.cargo/bin/cargo-get
       shell: bash
     - if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'macOS'
@@ -44,7 +44,7 @@ runs:
         current_target=$(rustc -Vv | grep host | cut -d ' ' -f 2)
         download_link=$(curl -s https://api.github.com/repos/nicolaiunrein/cargo-get/releases/latest | grep x86_64-apple-darwin\" | grep browser_download_url | cut -d: -f2,3 | tr -d '\"\ ')
         mkdir -p ~/.cargo/bin/
-        curl -sSfL "$download_link" -o ~/.cargo/bin/cargo-get
+        curl -sSfLo ~/.cargo/bin/cargo-get "$download_link"
         chmod +x ~/.cargo/bin/cargo-get
       shell: bash
     - id: cargo-get


### PR DESCRIPTION
As you can see from the screenshots below, the older version of the action was installing the cargo package on every run (every time there was a `step` in the CI file).
The new version will make sure that doesn't happen so that the users won't have to be billed as they use this action more than once.

![1](https://github.com/nicolaiunrein/cargo-get/assets/30233243/e12e6cf9-370d-45c2-9a3a-dc29b3edd21a)
![2](https://github.com/nicolaiunrein/cargo-get/assets/30233243/2519dec2-3077-4182-98a2-12d226d8341c)
