### PR TITLE
feat: add customizable terminators

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use std::{error::Error, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
 
-use crate::delimiter::Delimiter;
+use crate::{delimiter::Delimiter, terminator::Terminator};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -25,6 +25,14 @@ pub struct Cli {
         help = "Delimiter for array values"
     )]
     pub delimiter: Option<Delimiter>,
+
+    #[clap(
+        global = true,
+        long,
+        value_name = "CR | LF | CRLF | Nul | String",
+        help = "String terminator for the output that is returned"
+    )]
+    pub terminator: Option<Terminator>,
 }
 
 #[derive(Args, Clone)]

--- a/src/terminator.rs
+++ b/src/terminator.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub enum Terminator {
+    Cr,
+    CrLf,
+    #[default]
+    Lf,
+    Nul,
+    String(String),
+}
+
+impl fmt::Display for Terminator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            Self::Cr => "\r",
+            Self::CrLf => "\r\n",
+            Self::Lf => "\n",
+            Self::Nul => "\0",
+            Self::String(s) => s,
+        })
+    }
+}
+
+impl std::str::FromStr for Terminator {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_ref() {
+            "cr" => Ok(Self::Cr),
+            "crlf" => Ok(Self::CrLf),
+            "lf" => Ok(Self::Lf),
+            "nul" => Ok(Self::Nul),
+            _ => Ok(Self::String(s.to_owned())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn display_ok() {
+        let res = format!(
+            "{} {} {} {} {}",
+            Terminator::Cr,
+            Terminator::CrLf,
+            Terminator::Lf,
+            Terminator::Nul,
+            Terminator::String("abc!@#$%^&*()".to_owned())
+        );
+
+        let expected = "\r \r\n \n \0 abc!@#$%^&*()".to_owned();
+
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn parse_ok() -> Result<(), Box<dyn std::error::Error>> {
+        for (input, result) in [
+            ("Cr", Terminator::Cr),
+            ("CrLf", Terminator::CrLf),
+            ("Lf", Terminator::Lf),
+            ("Nul", Terminator::Nul),
+        ] {
+            assert_eq!(input.parse::<Terminator>()?, result);
+            assert_eq!(input.to_lowercase().parse::<Terminator>()?, result);
+            assert_eq!(input.to_uppercase().parse::<Terminator>()?, result);
+        }
+        Ok(())
+    }
+}

--- a/tests/terminator.rs
+++ b/tests/terminator.rs
@@ -1,0 +1,74 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn pkg_name_with_custom_terminator() {
+    let mut cmd = Command::cargo_bin("cargo-get").unwrap();
+    let p = std::fs::canonicalize("tests/data/toml_02").unwrap();
+    cmd.current_dir(p);
+
+    let assert = cmd.arg("package.name").arg("--terminator=.exe").assert();
+    assert
+        .success()
+        .stdout(predicate::eq(b"test-name.exe" as &[u8]));
+}
+
+#[test]
+fn pkg_name_with_cr_as_terminator() {
+    let mut cmd = Command::cargo_bin("cargo-get").unwrap();
+    let p = std::fs::canonicalize("tests/data/toml_02").unwrap();
+    cmd.current_dir(p);
+
+    let assert = cmd.arg("package.name").arg("--terminator=cr").assert();
+    assert
+        .success()
+        .stdout(predicate::eq(b"test-name\r" as &[u8]));
+}
+
+#[test]
+fn pkg_name_with_lf_as_terminator() {
+    let mut cmd = Command::cargo_bin("cargo-get").unwrap();
+    let p = std::fs::canonicalize("tests/data/toml_02").unwrap();
+    cmd.current_dir(p);
+
+    let assert = cmd.arg("package.name").arg("--terminator=lf").assert();
+    assert
+        .success()
+        .stdout(predicate::eq(b"test-name\n" as &[u8]));
+}
+
+#[test]
+fn pkg_name_with_crlf_as_terminator() {
+    let mut cmd = Command::cargo_bin("cargo-get").unwrap();
+    let p = std::fs::canonicalize("tests/data/toml_02").unwrap();
+    cmd.current_dir(p);
+
+    let assert = cmd.arg("package.name").arg("--terminator=crlf").assert();
+    assert
+        .success()
+        .stdout(predicate::eq(b"test-name\r\n" as &[u8]));
+}
+
+#[test]
+fn pkg_name_with_semicolon_as_terminator() {
+    let mut cmd = Command::cargo_bin("cargo-get").unwrap();
+    let p = std::fs::canonicalize("tests/data/toml_02").unwrap();
+    cmd.current_dir(p);
+
+    let assert = cmd.arg("package.name").arg("--terminator=;").assert();
+    assert
+        .success()
+        .stdout(predicate::eq(b"test-name;" as &[u8]));
+}
+
+#[test]
+fn pkg_name_with_nul_as_terminator() {
+    let mut cmd = Command::cargo_bin("cargo-get").unwrap();
+    let p = std::fs::canonicalize("tests/data/toml_02").unwrap();
+    cmd.current_dir(p);
+
+    let assert = cmd.arg("package.name").arg("--terminator=nul").assert();
+    assert
+        .success()
+        .stdout(predicate::eq(b"test-name\0" as &[u8]));
+}


### PR DESCRIPTION
Whiel using `cargo-get` in scripts, it is often useful to be able to change the ending character of the output -- ensuring that a newline does *not* get printed, adding a NUL terminator, etc.

This commit adds an option `--terminator` which changes the terminator that is printed after the requested output from `cargo-get`.

Resolves #14 