### PR TITLE
chore(ci): update actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,14 +28,14 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
     - name: Cache cargo index
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
@@ -54,14 +54,14 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
     - name: Cache cargo index
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
@@ -80,7 +80,7 @@ jobs:
         with:
           rust-version: stable
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Cargo Check
         run: cargo check
 
@@ -93,19 +93,19 @@ jobs:
           rust-version: stable
           components: clippy
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
@@ -116,11 +116,11 @@ jobs:
     name: fmt (ubuntu-latest, stable)
     runs-on: ubuntu-latest
     steps:
-      - uses: hecrj/setup-rust-action@v1
+      - uses: hecrj/setup-rust-action@v2
         with:
           rust-version: stable
           components: rustfmt
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Check Formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -22,7 +22,7 @@ jobs:
           - package.version
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get package metadata
         id: cargo-name
         uses: nicolaiunrein/cargo-get@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -41,9 +41,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -95,7 +95,7 @@ jobs:
           if-no-files-found: error
       - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         name: Upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}


### PR DESCRIPTION
This commit updates the GH actions that are in use to their latest unpinned versions. While it's arguable they should be pinned, this change deals with the update to prevent CI from breaking first (we can pin in a follow up).